### PR TITLE
Fix wrong exception and context to create_client method

### DIFF
--- a/mistral_actions/client/actions.py
+++ b/mistral_actions/client/actions.py
@@ -5,7 +5,7 @@ from oslo_config import cfg
 from oslo_utils import importutils
 
 from mistral.db.v2 import api as db_api
-from mistral.exceptions import NotFoundException
+from mistral.exceptions import DBEntityNotFoundError
 from mistral.services.action_manager import register_action_class
 from mistral.utils import inspect_utils as i_utils
 
@@ -53,7 +53,7 @@ def _extract_all_actions():
 def unregister(name):
     try:
         db_api.delete_action_definition(name)
-    except NotFoundException:
+    except DBEntityNotFoundError:
         print("Fail to remove action '%s', NOT FOUND!" % name)
 
 
@@ -64,7 +64,7 @@ def unregister_all():
         try:
             db_api.delete_action_definition(action['name'])
             print("Remove action '%s' successfully." % action['name'])
-        except NotFoundException:
+        except DBEntityNotFoundError:
             print("Fail to remove action '%s', NOT FOUND!" % action['name'])
 
 

--- a/mistral_actions/openstack.py
+++ b/mistral_actions/openstack.py
@@ -1,5 +1,6 @@
 from mistral.actions.base import Action as action_base
 from mistral.actions.openstack import actions as os_actions
+from mistral import context
 
 
 class OpenstackBase(action_base):
@@ -11,6 +12,6 @@ class OpenstackBase(action_base):
         action_obj = getattr(os_actions, "%sAction" % self.service)()
         # New version use _create_client()
         if hasattr(action_obj, '_create_client'):
-            return getattr(action_obj, '_create_client')()
+            return getattr(action_obj, '_create_client')(context.ctx())
         # Fallback to _get_client()
         return action_obj._get_client()


### PR DESCRIPTION
This patch fixes the wrong reference of NotFoundException which
is recently changed in mistral by replacing it with the new
exception 'DBEntityNotFoundError'. This patch also fixes the issue
of TypeError which gets raised if we don't pass context argument to
_create_client method of mistral_actions/openstack.py.